### PR TITLE
Add help message when 0 arguments are given

### DIFF
--- a/makeipsw.sh
+++ b/makeipsw.sh
@@ -4,8 +4,14 @@
 # made by nebula and nick chan
 # usage: ./makeipsw.sh <link to 14.8.1 ota> <deviceid, eg. iPhone10,6> <optional, aria2c download threads, default 32>
 
+if [ $# -eq 0  ]
+then
+    echo "Usage: $0 [link, 14.8.1 ota] [deviceid, eg. iPhone10,6] [threads, optional]" && exit 1
+fi
+
 set -e
 set -o xtrace
+
 mkdir -p ipsws
 sudo rm -rf work
 if [ -z "$VOLUME_NAME" ]; then


### PR DESCRIPTION
This small PR adds a help message, which will show up when 0 arguments are given when running the script.